### PR TITLE
Tech doctors/be faster on cache misses 57378292

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format progress

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem 'pry-nav'
 gem 'newrelic_rpm' # app monitoring
 
 gem 'term-ansicolor'
+gem 'rspec'
+gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,8 @@ gem 'pry-nav'
 gem 'newrelic_rpm' # app monitoring
 
 gem 'term-ansicolor'
-gem 'rspec'
-gem 'webmock'
+
+group :test do
+  gem 'rspec'
+  gem 'webmock'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,12 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.3.5)
     coderay (1.0.9)
+    crack (0.4.1)
+      safe_yaml (~> 0.9.0)
     dalli (2.6.4)
+    diff-lcs (1.2.4)
     dotenv (0.8.0)
     foreman (0.63.0)
       dotenv (>= 0.7)
@@ -24,6 +28,15 @@ GEM
       rack (~> 1.1)
       unicorn (~> 4.6, >= 4.6.2)
     raindrops (0.11.0)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.5)
+    rspec-expectations (2.14.3)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.3)
+    safe_yaml (0.9.7)
     sinatra (1.4.3)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -38,6 +51,9 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    webmock (1.13.0)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
@@ -49,5 +65,7 @@ DEPENDENCIES
   pry
   pry-nav
   rainbows
+  rspec
   sinatra
   term-ansicolor
+  webmock

--- a/config.ru
+++ b/config.ru
@@ -3,5 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'yarp/app'
 require 'yarp/initializers/new_relic'
+require 'yarp/fetcher'
 
+Yarp::Fetcher::Spawner.spawn_fetching_threads
 run Yarp::App

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 $:.unshift File.expand_path('../..', __FILE__)
 require 'yarp'
 require 'webmock/rspec'
-require 'stringio'
 require 'pry'
 
 # Load env variables with foreman

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,9 @@ $:.unshift File.expand_path('../..', __FILE__)
 require 'yarp'
 require 'webmock/rspec'
 require 'pry'
+require 'dotenv'
 
-# Load env variables with foreman
-require 'foreman/engine'
-Foreman::Engine.new.load_env('.env').each_pair do |key, value|
-  ENV[key] = value
-end
+Dotenv.load
 
 ENV['YARP_FILECACHE_PATH'] = 'tmp/test_cache'
 Yarp::Log.sev_threshold = Logger::FATAL

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,15 +11,8 @@ Foreman::Engine.new.load_env('.env').each_pair do |key, value|
 end
 
 ENV['YARP_FILECACHE_PATH'] = 'tmp/test_cache'
+Yarp::Log.sev_threshold = Logger::FATAL
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.run_all_when_everything_filtered = true
-  config.filter_run :focus
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
   config.order = 'random'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,25 @@
+$:.unshift File.expand_path('../..', __FILE__)
+require 'yarp'
+require 'webmock/rspec'
+require 'stringio'
+require 'pry'
+
+# Load env variables with foreman
+require 'foreman/engine'
+Foreman::Engine.new.load_env('.env').each_pair do |key, value|
+  ENV[key] = value
+end
+
+ENV['YARP_FILECACHE_PATH'] = 'tmp/test_cache'
+
+RSpec.configure do |config|
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = 'random'
+end

--- a/spec/yarp/fetcher/queue_spec.rb
+++ b/spec/yarp/fetcher/queue_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'yarp/fetcher/queue'
+require 'yarp/fetcher'
+
+describe Yarp::Fetcher::Queue do
+  subject { described_class.instance }
+
+  let(:fetcher) { Yarp::Fetcher.new('fetcher') }
+
+  before :each do
+    subject.clear
+  end
+
+
+  describe '.new' do
+    it 'raises an exception' do
+      expect {
+        described_class.new
+      }.to raise_error
+    end
+  end
+
+  describe 'instance' do
+    it 'returns same instance every time' do
+      subject.object_id.should == described_class.instance.object_id
+    end
+  end
+
+  describe '#<<' do
+    it 'puts object to queue' do
+      subject << fetcher
+      subject.length.should == 1
+    end
+
+    it 'does not allow to put two object to queue twice' do
+      subject << fetcher
+      subject << fetcher
+      subject.length.should == 1
+    end
+  end
+
+  describe '#done' do
+    it 'allows to put object with same path again' do
+      subject << fetcher
+      subject.done(fetcher)
+      subject << fetcher
+      subject.length.should == 2
+    end
+
+  end
+
+  describe '#pop' do
+    it 'pops element from queue' do
+      subject << fetcher
+      subject << Yarp::Fetcher.new('other fetcher')
+      subject.pop.should == fetcher
+    end
+  end
+end

--- a/spec/yarp/fetcher/spawner_spec.rb
+++ b/spec/yarp/fetcher/spawner_spec.rb
@@ -53,7 +53,7 @@ describe Yarp::Fetcher::Spawner do
           # waiting
         end
       end
-      Yarp::Fetcher::Queue.instance << stub(:path => 'a') # Stub doesn't respond to #fetch_from_upstream
+      Yarp::Fetcher::Queue.instance << double(:path => 'a') # Stub doesn't respond to #fetch_from_upstream
       expect {
         subject.join
       }.to raise_error(RSpec::Mocks::MockExpectationError)

--- a/spec/yarp/fetcher/spawner_spec.rb
+++ b/spec/yarp/fetcher/spawner_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'yarp/fetcher/spawner'
+
+describe Yarp::Fetcher::Spawner do
+
+  describe '.spawn_fetching_threads' do
+
+    subject { Yarp::Fetcher::Spawner }
+
+    it 'should spawn a number of threads' do
+      n = Yarp::Fetcher::Spawner::FETCHING_THREADS
+      subject.should_receive(:spawn_fetching_thread).exactly(n).times
+      subject.spawn_fetching_threads
+    end
+
+  end
+
+  describe '.spawn_fetching_thread' do
+
+    let(:fetcher) { Yarp::Fetcher.new('/abc') }
+
+    before :each do
+      stub_request(:get, "http://eu.yarp.io/abc").
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'eu.yarp.io', 'User-Agent'=>'Ruby'}).
+        to_return(:status => 200, :body => "a", :headers => { 'content-type' => '*/*', 'content-length' => '1' })
+      Yarp::Fetcher::Queue.instance.clear
+    end
+
+    subject { Yarp::Fetcher::Spawner.spawn_fetching_thread }
+
+    it 'should take a job from the queue' do
+      Yarp::Fetcher::Queue.instance << fetcher
+      Yarp::Fetcher::Queue.instance.should_receive(:pop).once
+      fetcher.should_receive(:fetch_from_upstream)
+      subject.join
+    end
+
+    # it 'should run the fetcher relevant method' do
+    #   fetcher.should_receive(:fetch_from_upstream)
+    #   Yarp::Fetcher::Queue.instance << fetcher
+    #   subject.join
+    # end
+
+  end
+
+
+end

--- a/spec/yarp/fetcher_spec.rb
+++ b/spec/yarp/fetcher_spec.rb
@@ -1,39 +1,43 @@
 require 'spec_helper'
 
 describe Yarp::Fetcher do
-  after :each do
-    described_class.paths_being_fetched.values.collect(&:join)
-  end
-
-  before :each do
-    Yarp::Cache::Memcache.new.send(:_connection).delete('06f74e7966946c1647930a899440755839f74e3e')
-  end
-
-  before :each do
-    stub_request(:get, "http://eu.yarp.io/abc").
-      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'eu.yarp.io', 'User-Agent'=>'Ruby'}).
-      to_return(:status => 200, :body => "a", :headers => { 'content-type' => '*/*', 'content-length' => '1' })
-  end
 
   describe '.fetch' do
+    subject { described_class.fetch('/abc') }
+
+    after :each do
+      described_class.paths_being_fetched.values.collect(&:join)
+    end
+
+    before :each do
+      Yarp::Cache::Memcache.new.send(:_connection).delete('06f74e7966946c1647930a899440755839f74e3e')
+      stub_request(:get, "http://eu.yarp.io/abc").
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'eu.yarp.io', 'User-Agent'=>'Ruby'}).
+        to_return(:status => 200, :body => "a", :headers => { 'content-type' => '*/*', 'content-length' => '1' })
+    end
+
     it 'returns value stored by cache' do
       described_class.cache.stub(:get => 'abc')
-      described_class.fetch('/abc').should == 'abc'
+      subject.should == 'abc'
     end
 
     context 'when no matching entry in cache' do
       it 'returns nil' do
-        described_class.fetch('/abc').should == nil
+        subject.should == nil
       end
 
       it 'uses apropriate cache key' do
         described_class.cache.should_receive(:get).with('06f74e7966946c1647930a899440755839f74e3e').at_least(:once)
-        described_class.fetch('/abc')
+        subject
       end
 
-      it 'schedules async fetch' do
-        described_class.fetch('/abc')
-        described_class.paths_being_fetched['/abc'].should be_kind_of(Thread)
+      it 'schedules one async fetch per path' do
+        expect {
+          described_class.fetch('/abc')
+          described_class.fetch('/abc')
+        }.to change {
+          described_class.paths_being_fetched.count
+        }.by(1)
       end
 
       it 'sets cache asynchronously' do

--- a/spec/yarp/fetcher_spec.rb
+++ b/spec/yarp/fetcher_spec.rb
@@ -6,7 +6,7 @@ describe Yarp::Fetcher do
 
   describe '.fetch' do
     it 'returns value stored by cache' do
-      Yarp::Cache.instance.stub(:get).and_return('abc')
+      Yarp::ConcreteCache.instance.stub(:get).and_return('abc')
       subject.should == 'abc'
     end
 
@@ -16,7 +16,7 @@ describe Yarp::Fetcher do
       end
 
       it 'uses apropriate cache key' do
-        Yarp::Cache.instance.should_receive(:get).with('06f74e7966946c1647930a899440755839f74e3e').at_least(:once)
+        Yarp::ConcreteCache.instance.should_receive(:get).with('06f74e7966946c1647930a899440755839f74e3e').at_least(:once)
         subject
       end
 
@@ -36,7 +36,7 @@ describe Yarp::Fetcher do
     end
 
     it 'fetches from upstream and sets cache' do
-      Yarp::Cache.instance.should_receive(:fetch) do |cache_key, ttl, &block|
+      Yarp::ConcreteCache.instance.should_receive(:fetch) do |cache_key, ttl, &block|
         cache_key.should == '06f74e7966946c1647930a899440755839f74e3e'
         block.call.should == [{"content-type"=>["*/*"], "content-length"=>["1"]}, "a"]
       end.and_return('abc')

--- a/spec/yarp/fetcher_spec.rb
+++ b/spec/yarp/fetcher_spec.rb
@@ -35,7 +35,7 @@ describe Yarp::Fetcher do
         to_return(:status => 200, :body => "a", :headers => { 'content-type' => '*/*', 'content-length' => '1' })
     end
 
-    it 'sets cache' do
+    it 'fetches from upstream and sets cache' do
       Yarp::Cache.instance.should_receive(:fetch) do |cache_key, ttl, &block|
         cache_key.should == '06f74e7966946c1647930a899440755839f74e3e'
         block.call.should == [{"content-type"=>["*/*"], "content-length"=>["1"]}, "a"]

--- a/spec/yarp/fetcher_spec.rb
+++ b/spec/yarp/fetcher_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'yarp/fetcher'
 
 describe Yarp::Fetcher do
-  subject { described_class.fetch('/abc') }
+  subject { described_class.new('/abc').fetch }
 
   describe '.fetch' do
     it 'returns value stored by cache' do

--- a/spec/yarp/fetcher_spec.rb
+++ b/spec/yarp/fetcher_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require 'yarp/fetcher'
 
 describe Yarp::Fetcher do
-  subject { described_class.new('/abc').fetch }
+  subject { described_class.new('/abc').perform }
 
-  describe '.fetch' do
+  describe '.perform' do
     it 'returns value stored by cache' do
       Yarp::ConcreteCache.instance.stub(:get).and_return('abc')
       subject.should == 'abc'

--- a/spec/yarp/fetcher_spec.rb
+++ b/spec/yarp/fetcher_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Yarp::Fetcher do
+  after :each do
+    described_class.paths_being_fetched.values.collect(&:join)
+  end
+
+  before :each do
+    Yarp::Cache::Memcache.new.send(:_connection).delete('06f74e7966946c1647930a899440755839f74e3e')
+  end
+
+  before :each do
+    stub_request(:get, "http://eu.yarp.io/abc").
+      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'eu.yarp.io', 'User-Agent'=>'Ruby'}).
+      to_return(:status => 200, :body => "a", :headers => { 'content-type' => '*/*', 'content-length' => '1' })
+  end
+
+  describe '.fetch' do
+    it 'returns value stored by cache' do
+      described_class.cache.stub(:get => 'abc')
+      described_class.fetch('/abc').should == 'abc'
+    end
+
+    context 'when no matching entry in cache' do
+      it 'returns nil' do
+        described_class.fetch('/abc').should == nil
+      end
+
+      it 'uses apropriate cache key' do
+        described_class.cache.should_receive(:get).with('06f74e7966946c1647930a899440755839f74e3e').at_least(:once)
+        described_class.fetch('/abc')
+      end
+
+      it 'schedules async fetch' do
+        described_class.fetch('/abc')
+        described_class.paths_being_fetched['/abc'].should be_kind_of(Thread)
+      end
+
+      it 'sets cache asynchronously' do
+        described_class.fetch('/abc')
+        described_class.paths_being_fetched.values.collect(&:join)
+        described_class.fetch('/abc').should == [{"content-type"=>["*/*"], "content-length"=>["1"]}, "a"]
+      end
+    end
+  end
+end

--- a/yarp.rb
+++ b/yarp.rb
@@ -7,5 +7,4 @@ require 'yarp/cache/tee'
 require 'yarp/logger'
 require 'yarp/fetcher'
 
-
 Yarp::Log = Yarp::Logger.new(STDERR)

--- a/yarp.rb
+++ b/yarp.rb
@@ -1,2 +1,11 @@
-module Yarp
-end
+module Yarp;end
+require 'yarp/ext/sliceable_hash'
+require 'yarp/cache/memcache'
+require 'yarp/cache/file'
+require 'yarp/cache/null'
+require 'yarp/cache/tee'
+require 'yarp/logger'
+require 'yarp/fetcher'
+
+
+Yarp::Log = Yarp::Logger.new(STDERR)

--- a/yarp.rb
+++ b/yarp.rb
@@ -1,10 +1,4 @@
-module Yarp;end
-require 'yarp/ext/sliceable_hash'
-require 'yarp/cache/memcache'
-require 'yarp/cache/file'
-require 'yarp/cache/null'
-require 'yarp/cache/tee'
 require 'yarp/logger'
-require 'yarp/fetcher'
-
-Yarp::Log = Yarp::Logger.new(STDERR)
+module Yarp
+  Log = Yarp::Logger.new(STDERR)
+end

--- a/yarp/app.rb
+++ b/yarp/app.rb
@@ -1,21 +1,8 @@
 require 'yarp'
-require 'yarp/ext/sliceable_hash'
-require 'yarp/cache/memcache'
-require 'yarp/cache/file'
-require 'yarp/cache/null'
-require 'yarp/cache/tee'
-require 'yarp/logger'
-require 'yarp/fetcher'
-
 require 'sinatra/base'
-require 'digest'
-require 'uri'
-require 'net/http'
-
 
 module Yarp
   class App < Sinatra::Base
-    RUBYGEMS_URL = ENV['YARP_UPSTREAM']
 
     CACHEABLE = %r{
       ^/api/v1/dependencies |
@@ -37,15 +24,10 @@ module Yarp
       path = full_request_path
       Log.info "REDIRECT <#{path}>"
       # $stderr.flush
-      redirect "#{RUBYGEMS_URL}#{path}"
+      redirect "#{ENV['YARP_UPSTREAM']}#{path}"
     end
 
   private
-
-    Log = Yarp::Logger.new(STDERR)
-    CACHE_TTL       = ENV['YARP_CACHE_TTL'].to_i
-    CACHE_THRESHOLD = ENV['YARP_CACHE_THRESHOLD'].to_i
-
     def get_cached_request(request)
       Log.debug "GET <#{full_request_path}>"
       cached_value = Yarp::Fetcher.fetch(full_request_path)
@@ -53,7 +35,7 @@ module Yarp
         [200, *cached_value]
       else
         Log.info "REDIRECT <#{full_request_path}>"
-        redirect "#{RUBYGEMS_URL}#{full_request_path}"
+        redirect "#{ENV['YARP_UPSTREAM']}#{full_request_path}"
       end
     end
 

--- a/yarp/app.rb
+++ b/yarp/app.rb
@@ -1,4 +1,5 @@
 require 'yarp'
+require 'yarp/fetcher'
 require 'sinatra/base'
 
 module Yarp

--- a/yarp/app.rb
+++ b/yarp/app.rb
@@ -5,6 +5,7 @@ require 'yarp/cache/file'
 require 'yarp/cache/null'
 require 'yarp/cache/tee'
 require 'yarp/logger'
+require 'yarp/fetcher'
 
 require 'sinatra/base'
 require 'digest'
@@ -46,26 +47,15 @@ module Yarp
     CACHE_THRESHOLD = ENV['YARP_CACHE_THRESHOLD'].to_i
 
     def get_cached_request(request)
-      path = full_request_path
-      cache_key = Digest::SHA1.hexdigest(path)
-      Log.debug "GET <#{path}> (#{cache_key})"
-
-      headers,payload =
-      cache.fetch(cache_key, CACHE_TTL) do
-        uri = URI("#{RUBYGEMS_URL}#{path}")
-        Log.debug "FETCH #{uri}"
-        response = fetch_with_redirects(uri)
-        kept_headers = response.to_hash.slice('content-type', 'content-length')
-        if response.code != '200'
-          return [response.code.to_i, response.to_hash, response.body]
-        end
-
-        [kept_headers, response.body]
+      Log.debug "GET <#{full_request_path}>"
+      cached_value = Yarp::Fetcher.fetch(full_request_path)
+      if cached_value
+        [200, *cached_value]
+      else
+        Log.info "REDIRECT <#{full_request_path}>"
+        redirect "#{RUBYGEMS_URL}#{full_request_path}"
       end
-
-      [200, headers, payload]
     end
-
 
     def full_request_path
       if request.query_string.length > 0
@@ -73,44 +63,6 @@ module Yarp
       else
         request.path
       end
-    end
-
-
-    def fetch_with_redirects(uri_str, limit = 10)
-      while limit > 0
-        begin
-          response = Net::HTTP.get_response(URI(uri_str))
-        rescue SocketError => e
-          Log.error("#{SocketError}: #{e.message}")
-          limit  -= 1
-          next
-        end
-
-        case response
-        when Net::HTTPRedirection then
-          uri_str = response['location']
-          limit  -= 1
-        else
-          return response
-        end
-      end
-      raise RuntimeError('too many HTTP redirects') if limit == 0
-    end
-
-    Cache = Yarp::Cache::Tee.new(
-      caches: {
-        memcache: Yarp::Cache::Memcache.new,
-        file:     Yarp::Cache::File.new,
-        null:     Yarp::Cache::Null.new
-      },
-      condition: lambda { |key, value|
-        value.last.length <= CACHE_THRESHOLD ? 
-          ENV['YARP_SMALL_CACHE'].to_sym : 
-          ENV['YARP_LARGE_CACHE'].to_sym
-      })
-
-    def cache
-      Cache
     end
   end
 end

--- a/yarp/app.rb
+++ b/yarp/app.rb
@@ -31,7 +31,7 @@ module Yarp
   private
     def get_cached_request(request)
       Log.debug "GET <#{full_request_path}>"
-      cached_value = Yarp::Fetcher.fetch(full_request_path)
+      cached_value = Yarp::Fetcher.new(full_request_path).fetch
       if cached_value
         [200, *cached_value]
       else

--- a/yarp/cache.rb
+++ b/yarp/cache.rb
@@ -11,7 +11,7 @@ module Yarp
     include Singleton
     extend Forwardable
 
-    def_delegators :@cache, :get, :fetch, :clear
+    def_delegators :@cache, :get, :fetch
 
     def initialize
       @cache = Yarp::Cache::Tee.new(

--- a/yarp/cache.rb
+++ b/yarp/cache.rb
@@ -1,0 +1,31 @@
+require 'singleton'
+require 'forwardable'
+require 'yarp/cache/memcache'
+require 'yarp/cache/file'
+require 'yarp/cache/null'
+require 'yarp/cache/tee'
+require 'yarp/ext/sliceable_hash'
+
+module Yarp
+  class Cache
+    include Singleton
+    extend Forwardable
+
+    def_delegators :@cache, :get, :fetch, :clear
+
+    def initialize
+      @cache = Yarp::Cache::Tee.new(
+        caches: {
+          memcache: Yarp::Cache::Memcache.new,
+          file:     Yarp::Cache::File.new,
+          null:     Yarp::Cache::Null.new
+        },
+        condition: lambda { |key, value|
+          value.last.length <= ENV['YARP_CACHE_THRESHOLD'].to_i ?
+            ENV['YARP_SMALL_CACHE'].to_sym :
+            ENV['YARP_LARGE_CACHE'].to_sym
+        }
+      )
+    end
+  end
+end

--- a/yarp/cache/base.rb
+++ b/yarp/cache/base.rb
@@ -1,15 +1,17 @@
 require 'yarp'
 
-module Yarp::Cache
-  class Base
+module Yarp
+  class Cache
+    class Base
 
-    def fetch(key, ttl=nil)
-      raise NotImplementedError("#{self.class.name} is abstract")
+      def fetch(key, ttl=nil)
+        raise NotImplementedError("#{self.class.name} is abstract")
+      end
+
+      def get(key)
+        raise NotImplementedError("#{self.class.name} is abstract")
+      end
+
     end
-
-    def get(key)
-      raise NotImplementedError("#{self.class.name} is abstract")
-    end
-
   end
 end

--- a/yarp/cache/base.rb
+++ b/yarp/cache/base.rb
@@ -1,17 +1,15 @@
 require 'yarp'
 
-module Yarp
-  class Cache
-    class Base
+module Yarp::Cache
+  class Base
 
-      def fetch(key, ttl=nil)
-        raise NotImplementedError("#{self.class.name} is abstract")
-      end
-
-      def get(key)
-        raise NotImplementedError("#{self.class.name} is abstract")
-      end
-
+    def fetch(key, ttl=nil)
+      raise NotImplementedError("#{self.class.name} is abstract")
     end
+
+    def get(key)
+      raise NotImplementedError("#{self.class.name} is abstract")
+    end
+
   end
 end

--- a/yarp/cache/file.rb
+++ b/yarp/cache/file.rb
@@ -3,201 +3,203 @@ require 'yarp/logger'
 require 'pathname'
 require 'uri'
 
-module Yarp::Cache
-  # A cache store implementation which stores everything on the filesystem.
-  # 
-  class File < Base
-    attr_reader :_cache_path
-    attr_reader :_max_bytes
+module Yarp
+  class Cache
+    # A cache store implementation which stores everything on the filesystem.
+    #
+    class File < Base
+      attr_reader :_cache_path
+      attr_reader :_max_bytes
 
 
-    def initialize(cache_path:nil, max_bytes:nil)
-      @_cache_path = cache_path ? cache_path.to_s : Pathname(ENV['YARP_FILECACHE_PATH'])
-      @_max_bytes  = max_bytes  ? max_bytes.to_i  : ENV['YARP_FILECACHE_MAX_BYTES'].to_i
-    end
-
-
-    def get(key)
-      now = Time.now.to_i
-      _edit_metadata do |metadata|
-        value = metadata[:files].delete(key)
-        return unless value
-
-        size,access,expiry = value
-        if expiry < now
-          _remove_expired
-          return
-        end
-
-        metadata[:files][key] = [size,now,expiry]
-        return Marshal.load(_cache_file(key).read)
-      end
-    end
-
-
-    def fetch(key, ttl=nil)
-      value = get(key) and return value
-      value = yield
-      _set(key, value, ttl)
-    end
-
-    def status
-      _edit_metadata do |metadata|
-        return { keys:metadata[:files].size, bytes:metadata[:bytes], size:_max_bytes }
-      end
-    end
-
-
-    def flush
-      _flush
-    end
-
-
-    # private
-
-    Log = Yarp::Logger.new(STDERR)
-    Lock = Mutex.new
-
-    # schema for metadata
-    # each file entry maps a key (the filename) to 3 integers: the size, the
-    # timestamp of last usage and timestamp of expiry.
-    # the first file is the least recently used.
-    def _default_meta
-      { bytes:0, files:{} }
-    end
-
-
-    # path to the file holding cache metadata
-    def _meta_path
-      @_meta_path ||= _cache_path.join('meta')
-    end
-
-    # path to the file used to store +key+
-    def _cache_file(key)
-      escaped_key = URI.encode_www_form_component(key)
-      _cache_path.join(escaped_key)
-    end
-
-    # empties the whole cache
-    def _flush
-      _edit_metadata do |metadata|
-        _cache_path.children.each do |child|
-          child.rmtree unless child == _meta_path
-        end
-        metadata.replace(DEFAULT_META)
-      end
-    end
-
-    # write a value to the cache
-    def _set(key, value, ttl=nil)
-      ttl  ||= 365 * 86400 # 1 year
-      now    = Time.now.to_i
-      expiry = now + ttl
-      data   = Marshal.dump(value)
-      size   = data.bytesize
-
-      # require 'pry' ; require 'pry-nav' ; binding.pry
-      _delete(key)
-      _make_space_for(size)
-      _cache_file(key).open('w') { |io| io.write(data) }
-      _edit_metadata do |metadata|
-        metadata[:bytes] += data.bytesize
-        metadata[:files][key] = [size,now,expiry]
+      def initialize(cache_path:nil, max_bytes:nil)
+        @_cache_path = cache_path ? cache_path.to_s : Pathname(ENV['YARP_FILECACHE_PATH'])
+        @_max_bytes  = max_bytes  ? max_bytes.to_i  : ENV['YARP_FILECACHE_MAX_BYTES'].to_i
       end
 
-      return value
-    end
 
-    def _delete(key)
-      _edit_metadata do |metadata|
-          size,_,_ = metadata[:files][key]
-          return false if size.nil?
-          metadata[:bytes] -= size
-          metadata[:files].delete(key)
-      end
-      _cache_file(key).delete
-      return true
-    end
+      def get(key)
+        now = Time.now.to_i
+        _edit_metadata do |metadata|
+          value = metadata[:files].delete(key)
+          return unless value
 
-    # removes expired cache entries (files) and updates metadata
-    def _remove_expired
-      now = Time.now.to_i
-      _edit_metadata do |metadata|
-        files_to_delete = []
-        metadata[:files].each_pair do |key,(size, _, expires)|
-          next unless expires < now
-          _cache_file(key).delete
-          metadata[:bytes] -= size
-          metadata[:files].delete(key)
+          size,access,expiry = value
+          if expiry < now
+            _remove_expired
+            return
+          end
+
+          metadata[:files][key] = [size,now,expiry]
+          return Marshal.load(_cache_file(key).read)
         end
       end
-    end
 
-    # removes files from the cache until there is enought space for +bytes+
-    def _make_space_for(bytes)
-      raise ArgumentError("cannot store files larger than the cache") if bytes > _max_bytes
-      _edit_metadata do |metadata|
-        while bytes > _max_bytes - metadata[:bytes]
-          key,(size,_,_) = metadata[:files].first
-          Log.warn "FILECACHE evicting #{key}"
-          _cache_file(key).delete
-          metadata[:files].delete(key)
-          metadata[:bytes] -= size
+
+      def fetch(key, ttl=nil)
+        value = get(key) and return value
+        value = yield
+        _set(key, value, ttl)
+      end
+
+      def status
+        _edit_metadata do |metadata|
+          return { keys:metadata[:files].size, bytes:metadata[:bytes], size:_max_bytes }
         end
       end
-    end
 
-    # executes the given block while holding a lock on the meta file.
-    # yield an IO for the meta file.
-    # reentrant (yields the same descriptor if called recursively).
-    def _with_lock
-      return yield @_meta_fd if @_meta_fd
-      _meta_path.parent.mkpath
-      _meta_path.open(::File::CREAT | ::File::RDWR) do |io|
-        Lock.synchronize do
-          begin
-            @_meta_fd = io
-            io.flock(::File::LOCK_EX)
-            yield @_meta_fd
-          ensure
-            io.flock(::File::LOCK_UN)
-            @_meta_fd = nil
+
+      def flush
+        _flush
+      end
+
+
+      # private
+
+      Log = Yarp::Logger.new(STDERR)
+      Lock = Mutex.new
+
+      # schema for metadata
+      # each file entry maps a key (the filename) to 3 integers: the size, the
+      # timestamp of last usage and timestamp of expiry.
+      # the first file is the least recently used.
+      def _default_meta
+        { bytes:0, files:{} }
+      end
+
+
+      # path to the file holding cache metadata
+      def _meta_path
+        @_meta_path ||= _cache_path.join('meta')
+      end
+
+      # path to the file used to store +key+
+      def _cache_file(key)
+        escaped_key = URI.encode_www_form_component(key)
+        _cache_path.join(escaped_key)
+      end
+
+      # empties the whole cache
+      def _flush
+        _edit_metadata do |metadata|
+          _cache_path.children.each do |child|
+            child.rmtree unless child == _meta_path
+          end
+          metadata.replace(DEFAULT_META)
+        end
+      end
+
+      # write a value to the cache
+      def _set(key, value, ttl=nil)
+        ttl  ||= 365 * 86400 # 1 year
+        now    = Time.now.to_i
+        expiry = now + ttl
+        data   = Marshal.dump(value)
+        size   = data.bytesize
+
+        # require 'pry' ; require 'pry-nav' ; binding.pry
+        _delete(key)
+        _make_space_for(size)
+        _cache_file(key).open('w') { |io| io.write(data) }
+        _edit_metadata do |metadata|
+          metadata[:bytes] += data.bytesize
+          metadata[:files][key] = [size,now,expiry]
+        end
+
+        return value
+      end
+
+      def _delete(key)
+        _edit_metadata do |metadata|
+            size,_,_ = metadata[:files][key]
+            return false if size.nil?
+            metadata[:bytes] -= size
+            metadata[:files].delete(key)
+        end
+        _cache_file(key).delete
+        return true
+      end
+
+      # removes expired cache entries (files) and updates metadata
+      def _remove_expired
+        now = Time.now.to_i
+        _edit_metadata do |metadata|
+          files_to_delete = []
+          metadata[:files].each_pair do |key,(size, _, expires)|
+            next unless expires < now
+            _cache_file(key).delete
+            metadata[:bytes] -= size
+            metadata[:files].delete(key)
           end
         end
       end
-    end
 
-    # yields the current metadata (should be a mutable hash).
-    # writes data back (even if unmodified) after running the block.
-    # implicitly locks the metadata file.
-    # reentrant (nested calls are passed the same mutable hash).
-    def _edit_metadata
-      return yield @_metadata if @_metadata
-      _with_lock do |io|
-        io.seek(0)
-        raw = io.read()
-        @_metadata = begin
-          raw.length == 0 ? _default_meta.dup : Marshal.load(raw)
-        rescue ArgumentError, TypeError
-          Log.warn("FILECACHE resetting broken metatada")
-          _default_meta.dup
-        end
-
-        begin
-          yield @_metadata
-        ensure
-          # Log.debug("FILECACHE metadata before write #{@_metadata.inspect}")
-          raw = Marshal.dump(@_metadata)
-
-          io.seek(0)
-          io.truncate(raw.bytesize)
-          io.write(raw)
-          io.flush
-          @_metadata = nil
+      # removes files from the cache until there is enought space for +bytes+
+      def _make_space_for(bytes)
+        raise ArgumentError("cannot store files larger than the cache") if bytes > _max_bytes
+        _edit_metadata do |metadata|
+          while bytes > _max_bytes - metadata[:bytes]
+            key,(size,_,_) = metadata[:files].first
+            Log.warn "FILECACHE evicting #{key}"
+            _cache_file(key).delete
+            metadata[:files].delete(key)
+            metadata[:bytes] -= size
+          end
         end
       end
+
+      # executes the given block while holding a lock on the meta file.
+      # yield an IO for the meta file.
+      # reentrant (yields the same descriptor if called recursively).
+      def _with_lock
+        return yield @_meta_fd if @_meta_fd
+        _meta_path.parent.mkpath
+        _meta_path.open(::File::CREAT | ::File::RDWR) do |io|
+          Lock.synchronize do
+            begin
+              @_meta_fd = io
+              io.flock(::File::LOCK_EX)
+              yield @_meta_fd
+            ensure
+              io.flock(::File::LOCK_UN)
+              @_meta_fd = nil
+            end
+          end
+        end
+      end
+
+      # yields the current metadata (should be a mutable hash).
+      # writes data back (even if unmodified) after running the block.
+      # implicitly locks the metadata file.
+      # reentrant (nested calls are passed the same mutable hash).
+      def _edit_metadata
+        return yield @_metadata if @_metadata
+        _with_lock do |io|
+          io.seek(0)
+          raw = io.read()
+          @_metadata = begin
+            raw.length == 0 ? _default_meta.dup : Marshal.load(raw)
+          rescue ArgumentError, TypeError
+            Log.warn("FILECACHE resetting broken metatada")
+            _default_meta.dup
+          end
+
+          begin
+            yield @_metadata
+          ensure
+            # Log.debug("FILECACHE metadata before write #{@_metadata.inspect}")
+            raw = Marshal.dump(@_metadata)
+
+            io.seek(0)
+            io.truncate(raw.bytesize)
+            io.write(raw)
+            io.flush
+            @_metadata = nil
+          end
+        end
+      end
+
+
     end
-
-
   end
 end

--- a/yarp/cache/file.rb
+++ b/yarp/cache/file.rb
@@ -3,203 +3,201 @@ require 'yarp/logger'
 require 'pathname'
 require 'uri'
 
-module Yarp
-  class Cache
-    # A cache store implementation which stores everything on the filesystem.
-    #
-    class File < Base
-      attr_reader :_cache_path
-      attr_reader :_max_bytes
+module Yarp::Cache
+  # A cache store implementation which stores everything on the filesystem.
+  #
+  class File < Base
+    attr_reader :_cache_path
+    attr_reader :_max_bytes
 
 
-      def initialize(cache_path:nil, max_bytes:nil)
-        @_cache_path = cache_path ? cache_path.to_s : Pathname(ENV['YARP_FILECACHE_PATH'])
-        @_max_bytes  = max_bytes  ? max_bytes.to_i  : ENV['YARP_FILECACHE_MAX_BYTES'].to_i
-      end
-
-
-      def get(key)
-        now = Time.now.to_i
-        _edit_metadata do |metadata|
-          value = metadata[:files].delete(key)
-          return unless value
-
-          size,access,expiry = value
-          if expiry < now
-            _remove_expired
-            return
-          end
-
-          metadata[:files][key] = [size,now,expiry]
-          return Marshal.load(_cache_file(key).read)
-        end
-      end
-
-
-      def fetch(key, ttl=nil)
-        value = get(key) and return value
-        value = yield
-        _set(key, value, ttl)
-      end
-
-      def status
-        _edit_metadata do |metadata|
-          return { keys:metadata[:files].size, bytes:metadata[:bytes], size:_max_bytes }
-        end
-      end
-
-
-      def flush
-        _flush
-      end
-
-
-      # private
-
-      Log = Yarp::Logger.new(STDERR)
-      Lock = Mutex.new
-
-      # schema for metadata
-      # each file entry maps a key (the filename) to 3 integers: the size, the
-      # timestamp of last usage and timestamp of expiry.
-      # the first file is the least recently used.
-      def _default_meta
-        { bytes:0, files:{} }
-      end
-
-
-      # path to the file holding cache metadata
-      def _meta_path
-        @_meta_path ||= _cache_path.join('meta')
-      end
-
-      # path to the file used to store +key+
-      def _cache_file(key)
-        escaped_key = URI.encode_www_form_component(key)
-        _cache_path.join(escaped_key)
-      end
-
-      # empties the whole cache
-      def _flush
-        _edit_metadata do |metadata|
-          _cache_path.children.each do |child|
-            child.rmtree unless child == _meta_path
-          end
-          metadata.replace(DEFAULT_META)
-        end
-      end
-
-      # write a value to the cache
-      def _set(key, value, ttl=nil)
-        ttl  ||= 365 * 86400 # 1 year
-        now    = Time.now.to_i
-        expiry = now + ttl
-        data   = Marshal.dump(value)
-        size   = data.bytesize
-
-        # require 'pry' ; require 'pry-nav' ; binding.pry
-        _delete(key)
-        _make_space_for(size)
-        _cache_file(key).open('w') { |io| io.write(data) }
-        _edit_metadata do |metadata|
-          metadata[:bytes] += data.bytesize
-          metadata[:files][key] = [size,now,expiry]
-        end
-
-        return value
-      end
-
-      def _delete(key)
-        _edit_metadata do |metadata|
-            size,_,_ = metadata[:files][key]
-            return false if size.nil?
-            metadata[:bytes] -= size
-            metadata[:files].delete(key)
-        end
-        _cache_file(key).delete
-        return true
-      end
-
-      # removes expired cache entries (files) and updates metadata
-      def _remove_expired
-        now = Time.now.to_i
-        _edit_metadata do |metadata|
-          files_to_delete = []
-          metadata[:files].each_pair do |key,(size, _, expires)|
-            next unless expires < now
-            _cache_file(key).delete
-            metadata[:bytes] -= size
-            metadata[:files].delete(key)
-          end
-        end
-      end
-
-      # removes files from the cache until there is enought space for +bytes+
-      def _make_space_for(bytes)
-        raise ArgumentError("cannot store files larger than the cache") if bytes > _max_bytes
-        _edit_metadata do |metadata|
-          while bytes > _max_bytes - metadata[:bytes]
-            key,(size,_,_) = metadata[:files].first
-            Log.warn "FILECACHE evicting #{key}"
-            _cache_file(key).delete
-            metadata[:files].delete(key)
-            metadata[:bytes] -= size
-          end
-        end
-      end
-
-      # executes the given block while holding a lock on the meta file.
-      # yield an IO for the meta file.
-      # reentrant (yields the same descriptor if called recursively).
-      def _with_lock
-        return yield @_meta_fd if @_meta_fd
-        _meta_path.parent.mkpath
-        _meta_path.open(::File::CREAT | ::File::RDWR) do |io|
-          Lock.synchronize do
-            begin
-              @_meta_fd = io
-              io.flock(::File::LOCK_EX)
-              yield @_meta_fd
-            ensure
-              io.flock(::File::LOCK_UN)
-              @_meta_fd = nil
-            end
-          end
-        end
-      end
-
-      # yields the current metadata (should be a mutable hash).
-      # writes data back (even if unmodified) after running the block.
-      # implicitly locks the metadata file.
-      # reentrant (nested calls are passed the same mutable hash).
-      def _edit_metadata
-        return yield @_metadata if @_metadata
-        _with_lock do |io|
-          io.seek(0)
-          raw = io.read()
-          @_metadata = begin
-            raw.length == 0 ? _default_meta.dup : Marshal.load(raw)
-          rescue ArgumentError, TypeError
-            Log.warn("FILECACHE resetting broken metatada")
-            _default_meta.dup
-          end
-
-          begin
-            yield @_metadata
-          ensure
-            # Log.debug("FILECACHE metadata before write #{@_metadata.inspect}")
-            raw = Marshal.dump(@_metadata)
-
-            io.seek(0)
-            io.truncate(raw.bytesize)
-            io.write(raw)
-            io.flush
-            @_metadata = nil
-          end
-        end
-      end
-
-
+    def initialize(cache_path:nil, max_bytes:nil)
+      @_cache_path = cache_path ? cache_path.to_s : Pathname(ENV['YARP_FILECACHE_PATH'])
+      @_max_bytes  = max_bytes  ? max_bytes.to_i  : ENV['YARP_FILECACHE_MAX_BYTES'].to_i
     end
+
+
+    def get(key)
+      now = Time.now.to_i
+      _edit_metadata do |metadata|
+        value = metadata[:files].delete(key)
+        return unless value
+
+        size,access,expiry = value
+        if expiry < now
+          _remove_expired
+          return
+        end
+
+        metadata[:files][key] = [size,now,expiry]
+        return Marshal.load(_cache_file(key).read)
+      end
+    end
+
+
+    def fetch(key, ttl=nil)
+      value = get(key) and return value
+      value = yield
+      _set(key, value, ttl)
+    end
+
+    def status
+      _edit_metadata do |metadata|
+        return { keys:metadata[:files].size, bytes:metadata[:bytes], size:_max_bytes }
+      end
+    end
+
+
+    def flush
+      _flush
+    end
+
+
+    # private
+
+    Log = Yarp::Logger.new(STDERR)
+    Lock = Mutex.new
+
+    # schema for metadata
+    # each file entry maps a key (the filename) to 3 integers: the size, the
+    # timestamp of last usage and timestamp of expiry.
+    # the first file is the least recently used.
+    def _default_meta
+      { bytes:0, files:{} }
+    end
+
+
+    # path to the file holding cache metadata
+    def _meta_path
+      @_meta_path ||= _cache_path.join('meta')
+    end
+
+    # path to the file used to store +key+
+    def _cache_file(key)
+      escaped_key = URI.encode_www_form_component(key)
+      _cache_path.join(escaped_key)
+    end
+
+    # empties the whole cache
+    def _flush
+      _edit_metadata do |metadata|
+        _cache_path.children.each do |child|
+          child.rmtree unless child == _meta_path
+        end
+        metadata.replace(DEFAULT_META)
+      end
+    end
+
+    # write a value to the cache
+    def _set(key, value, ttl=nil)
+      ttl  ||= 365 * 86400 # 1 year
+      now    = Time.now.to_i
+      expiry = now + ttl
+      data   = Marshal.dump(value)
+      size   = data.bytesize
+
+      # require 'pry' ; require 'pry-nav' ; binding.pry
+      _delete(key)
+      _make_space_for(size)
+      _cache_file(key).open('w') { |io| io.write(data) }
+      _edit_metadata do |metadata|
+        metadata[:bytes] += data.bytesize
+        metadata[:files][key] = [size,now,expiry]
+      end
+
+      return value
+    end
+
+    def _delete(key)
+      _edit_metadata do |metadata|
+          size,_,_ = metadata[:files][key]
+          return false if size.nil?
+          metadata[:bytes] -= size
+          metadata[:files].delete(key)
+      end
+      _cache_file(key).delete
+      return true
+    end
+
+    # removes expired cache entries (files) and updates metadata
+    def _remove_expired
+      now = Time.now.to_i
+      _edit_metadata do |metadata|
+        files_to_delete = []
+        metadata[:files].each_pair do |key,(size, _, expires)|
+          next unless expires < now
+          _cache_file(key).delete
+          metadata[:bytes] -= size
+          metadata[:files].delete(key)
+        end
+      end
+    end
+
+    # removes files from the cache until there is enought space for +bytes+
+    def _make_space_for(bytes)
+      raise ArgumentError("cannot store files larger than the cache") if bytes > _max_bytes
+      _edit_metadata do |metadata|
+        while bytes > _max_bytes - metadata[:bytes]
+          key,(size,_,_) = metadata[:files].first
+          Log.warn "FILECACHE evicting #{key}"
+          _cache_file(key).delete
+          metadata[:files].delete(key)
+          metadata[:bytes] -= size
+        end
+      end
+    end
+
+    # executes the given block while holding a lock on the meta file.
+    # yield an IO for the meta file.
+    # reentrant (yields the same descriptor if called recursively).
+    def _with_lock
+      return yield @_meta_fd if @_meta_fd
+      _meta_path.parent.mkpath
+      _meta_path.open(::File::CREAT | ::File::RDWR) do |io|
+        Lock.synchronize do
+          begin
+            @_meta_fd = io
+            io.flock(::File::LOCK_EX)
+            yield @_meta_fd
+          ensure
+            io.flock(::File::LOCK_UN)
+            @_meta_fd = nil
+          end
+        end
+      end
+    end
+
+    # yields the current metadata (should be a mutable hash).
+    # writes data back (even if unmodified) after running the block.
+    # implicitly locks the metadata file.
+    # reentrant (nested calls are passed the same mutable hash).
+    def _edit_metadata
+      return yield @_metadata if @_metadata
+      _with_lock do |io|
+        io.seek(0)
+        raw = io.read()
+        @_metadata = begin
+          raw.length == 0 ? _default_meta.dup : Marshal.load(raw)
+        rescue ArgumentError, TypeError
+          Log.warn("FILECACHE resetting broken metatada")
+          _default_meta.dup
+        end
+
+        begin
+          yield @_metadata
+        ensure
+          # Log.debug("FILECACHE metadata before write #{@_metadata.inspect}")
+          raw = Marshal.dump(@_metadata)
+
+          io.seek(0)
+          io.truncate(raw.bytesize)
+          io.write(raw)
+          io.flush
+          @_metadata = nil
+        end
+      end
+    end
+
+
   end
 end

--- a/yarp/cache/memcache.rb
+++ b/yarp/cache/memcache.rb
@@ -1,27 +1,25 @@
 require 'yarp/cache/base'
 require 'dalli'
 
-module Yarp
-  class Cache
-    class Memcache
+module Yarp::Cache
+  class Memcache
 
-      def fetch(key, ttl=nil)
-        _connection.fetch(key, ttl) { yield or return }
-      end
+    def fetch(key, ttl=nil)
+      _connection.fetch(key, ttl) { yield or return }
+    end
 
-      def get(key)
-        _connection.get(key)
-      end
+    def get(key)
+      _connection.get(key)
+    end
 
-      private
+    private
 
-      def _connection
-        @_connection ||= Dalli::Client.new(
-          ENV['MEMCACHIER_SERVERS'].split(','),
-          username: ENV['MEMCACHIER_USERNAME'],
-          password: ENV['MEMCACHIER_PASSWORD'],
-          compress: true)
-      end
+    def _connection
+      @_connection ||= Dalli::Client.new(
+        ENV['MEMCACHIER_SERVERS'].split(','),
+        username: ENV['MEMCACHIER_USERNAME'],
+        password: ENV['MEMCACHIER_PASSWORD'],
+        compress: true)
     end
   end
 end

--- a/yarp/cache/memcache.rb
+++ b/yarp/cache/memcache.rb
@@ -1,25 +1,31 @@
 require 'yarp/cache/base'
 require 'dalli'
 
-module Yarp::Cache
-  class Memcache
+module Yarp
+  class Cache
+    class Memcache
 
-    def fetch(key, ttl=nil)
-      _connection.fetch(key, ttl) { yield or return }
-    end
+      def fetch(key, ttl=nil)
+        _connection.fetch(key, ttl) { yield or return }
+      end
 
-    def get(key)
-      _connection.get(key)
-    end
+      def get(key)
+        _connection.get(key)
+      end
 
-    private
+      def clear
+        _connection.flush_all
+      end
 
-    def _connection
-      @_connection ||= Dalli::Client.new(
-        ENV['MEMCACHIER_SERVERS'].split(','),
-        username: ENV['MEMCACHIER_USERNAME'],
-        password: ENV['MEMCACHIER_PASSWORD'],
-        compress: true)
+      private
+
+      def _connection
+        @_connection ||= Dalli::Client.new(
+          ENV['MEMCACHIER_SERVERS'].split(','),
+          username: ENV['MEMCACHIER_USERNAME'],
+          password: ENV['MEMCACHIER_PASSWORD'],
+          compress: true)
+      end
     end
   end
 end

--- a/yarp/cache/memcache.rb
+++ b/yarp/cache/memcache.rb
@@ -13,10 +13,6 @@ module Yarp
         _connection.get(key)
       end
 
-      def clear
-        _connection.flush_all
-      end
-
       private
 
       def _connection

--- a/yarp/cache/null.rb
+++ b/yarp/cache/null.rb
@@ -1,17 +1,15 @@
 require 'yarp/cache/base'
 
-module Yarp
-  class Cache
-    class Null
+module Yarp::Cache
+  class Null
 
-      def fetch(key, ttl=nil)
-        yield
-      end
-
-      def get(key)
-        nil
-      end
-
+    def fetch(key, ttl=nil)
+      yield
     end
+
+    def get(key)
+      nil
+    end
+
   end
 end

--- a/yarp/cache/null.rb
+++ b/yarp/cache/null.rb
@@ -1,15 +1,17 @@
 require 'yarp/cache/base'
 
-module Yarp::Cache
-  class Null
+module Yarp
+  class Cache
+    class Null
 
-    def fetch(key, ttl=nil)
-      yield
+      def fetch(key, ttl=nil)
+        yield
+      end
+
+      def get(key)
+        nil
+      end
+
     end
-
-    def get(key)
-      nil
-    end
-
   end
 end

--- a/yarp/cache/tee.rb
+++ b/yarp/cache/tee.rb
@@ -1,12 +1,10 @@
 require 'yarp/cache/base'
-require 'yarp/logger'
 
 module Yarp::Cache
   class Tee
     attr_reader :_caches
     attr_reader :_condition
 
-    Log = Yarp::Logger.new(STDERR)
 
     # - condition: proc that accepts a key and payload size, and yields a symbol
     # - caches: a hash of symbols to caches
@@ -22,7 +20,7 @@ module Yarp::Cache
     def get(key)
       _caches.each_pair do |cache_name, cache|
         next unless v = cache.get(key)
-        Log.info "TEE cache hit #{key} <- #{cache_name}"
+        Yarp::Log.info "TEE cache hit #{key} <- #{cache_name}"
         return v
       end
       nil
@@ -33,7 +31,7 @@ module Yarp::Cache
       v = get(key) and return v
       value = yield
       cache_name = _condition.call(key, value)
-      Log.warn "TEE cache miss #{key} -> #{cache_name} (ttl #{ttl})"
+      Yarp::Log.warn "TEE cache miss #{key} -> #{cache_name} (ttl #{ttl})"
       _caches[cache_name].fetch(key, ttl) { value }
     end
 

--- a/yarp/cache/tee.rb
+++ b/yarp/cache/tee.rb
@@ -36,9 +36,6 @@ module Yarp
         _caches[cache_name].fetch(key, ttl) { value }
       end
 
-      def clear
-        @_caches.each{ |cache| cache.clear rescue nil }
-      end
 
     end
   end

--- a/yarp/cache/tee.rb
+++ b/yarp/cache/tee.rb
@@ -1,42 +1,40 @@
 require 'yarp/cache/base'
 
-module Yarp
-  class Cache
-    class Tee
-      attr_reader :_caches
-      attr_reader :_condition
+module Yarp::Cache
+  class Tee
+    attr_reader :_caches
+    attr_reader :_condition
 
 
-      # - condition: proc that accepts a key and payload size, and yields a symbol
-      # - caches: a hash of symbols to caches
-      #
-      # All symbols listed by the +condition+ must be in the +caches+.
-      #
-      def initialize(condition:nil, caches:nil)
-        @_caches    = caches
-        @_condition = condition
-      end
-
-
-      def get(key)
-        _caches.each_pair do |cache_name, cache|
-          next unless v = cache.get(key)
-          Yarp::Log.info "TEE cache hit #{key} <- #{cache_name}"
-          return v
-        end
-        nil
-      end
-
-
-      def fetch(key, ttl)
-        v = get(key) and return v
-        value = yield
-        cache_name = _condition.call(key, value)
-        Yarp::Log.warn "TEE cache miss #{key} -> #{cache_name} (ttl #{ttl})"
-        _caches[cache_name].fetch(key, ttl) { value }
-      end
-
-
+    # - condition: proc that accepts a key and payload size, and yields a symbol
+    # - caches: a hash of symbols to caches
+    #
+    # All symbols listed by the +condition+ must be in the +caches+.
+    #
+    def initialize(condition:nil, caches:nil)
+      @_caches    = caches
+      @_condition = condition
     end
+
+
+    def get(key)
+      _caches.each_pair do |cache_name, cache|
+        next unless v = cache.get(key)
+        Yarp::Log.info "TEE cache hit #{key} <- #{cache_name}"
+        return v
+      end
+      nil
+    end
+
+
+    def fetch(key, ttl)
+      v = get(key) and return v
+      value = yield
+      cache_name = _condition.call(key, value)
+      Yarp::Log.warn "TEE cache miss #{key} -> #{cache_name} (ttl #{ttl})"
+      _caches[cache_name].fetch(key, ttl) { value }
+    end
+
+
   end
 end

--- a/yarp/cache/tee.rb
+++ b/yarp/cache/tee.rb
@@ -1,39 +1,45 @@
 require 'yarp/cache/base'
 
-module Yarp::Cache
-  class Tee
-    attr_reader :_caches
-    attr_reader :_condition
+module Yarp
+  class Cache
+    class Tee
+      attr_reader :_caches
+      attr_reader :_condition
 
 
-    # - condition: proc that accepts a key and payload size, and yields a symbol
-    # - caches: a hash of symbols to caches
-    # 
-    # All symbols listed by the +condition+ must be in the +caches+.
-    # 
-    def initialize(condition:nil, caches:nil)
-      @_caches    = caches
-      @_condition = condition
-    end
-
-
-    def get(key)
-      _caches.each_pair do |cache_name, cache|
-        next unless v = cache.get(key)
-        Yarp::Log.info "TEE cache hit #{key} <- #{cache_name}"
-        return v
+      # - condition: proc that accepts a key and payload size, and yields a symbol
+      # - caches: a hash of symbols to caches
+      #
+      # All symbols listed by the +condition+ must be in the +caches+.
+      #
+      def initialize(condition:nil, caches:nil)
+        @_caches    = caches
+        @_condition = condition
       end
-      nil
+
+
+      def get(key)
+        _caches.each_pair do |cache_name, cache|
+          next unless v = cache.get(key)
+          Yarp::Log.info "TEE cache hit #{key} <- #{cache_name}"
+          return v
+        end
+        nil
+      end
+
+
+      def fetch(key, ttl)
+        v = get(key) and return v
+        value = yield
+        cache_name = _condition.call(key, value)
+        Yarp::Log.warn "TEE cache miss #{key} -> #{cache_name} (ttl #{ttl})"
+        _caches[cache_name].fetch(key, ttl) { value }
+      end
+
+      def clear
+        @_caches.each{ |cache| cache.clear rescue nil }
+      end
+
     end
-
-
-    def fetch(key, ttl)
-      v = get(key) and return v
-      value = yield
-      cache_name = _condition.call(key, value)
-      Yarp::Log.warn "TEE cache miss #{key} -> #{cache_name} (ttl #{ttl})"
-      _caches[cache_name].fetch(key, ttl) { value }
-    end
-
   end
 end

--- a/yarp/concrete_cache.rb
+++ b/yarp/concrete_cache.rb
@@ -7,7 +7,7 @@ require 'yarp/cache/tee'
 require 'yarp/ext/sliceable_hash'
 
 module Yarp
-  class Cache
+  class ConcreteCache
     include Singleton
     extend Forwardable
 

--- a/yarp/fetcher.rb
+++ b/yarp/fetcher.rb
@@ -1,0 +1,84 @@
+module Yarp
+  class Fetcher
+
+    @paths_being_fetched = {}
+
+    singleton_class.class_eval do
+      attr_accessor :paths_being_fetched
+    end
+
+    def self.fetch(path)
+      new(path).fetch
+    end
+
+    def initialize(path)
+      @path = path
+    end
+
+    def fetch
+      cached_value = self.class.cache.get(cache_key)
+      return cached_value if cached_value
+      async_fetch
+      return
+    end
+
+    def self.cache
+      @cache ||= Yarp::Cache::Tee.new(
+        caches: {
+          memcache: Yarp::Cache::Memcache.new,
+          file:     Yarp::Cache::File.new,
+          null:     Yarp::Cache::Null.new
+        },
+        condition: lambda { |key, value|
+          value.last.length <= CACHE_THRESHOLD ?
+            ENV['YARP_SMALL_CACHE'].to_sym :
+            ENV['YARP_LARGE_CACHE'].to_sym
+        }
+      )
+    end
+
+    private
+
+    def async_fetch
+      return if self.path_being_fetched[@path]
+      self.path_being_fetched[@path] = Thread.new(@path, cache_key) do |request_path, key|
+        self.class.cache.fetch(key, CACHE_TTL) do
+          uri = URI("#{RUBYGEMS_URL}#{request_path}")
+          Log.debug "FETCH #{uri}"
+          response = self.class.fetch_with_redirects(uri)
+          kept_headers = response.to_hash.slice('content-type', 'content-length')
+          if response.code != '200'
+            return [response.code.to_i, response.to_hash, response.body]
+          end
+          [kept_headers, response.body]
+        end
+        self.path_being_fetched.delete(request_path)
+      end
+    end
+
+    def self.fetch_with_redirects(uri_str, limit = 10)
+      while limit > 0
+        begin
+          response = Net::HTTP.get_response(URI(uri_str))
+        rescue SocketError => e
+          Log.error("#{SocketError}: #{e.message}")
+          limit  -= 1
+          next
+        end
+
+        case response
+        when Net::HTTPRedirection then
+          uri_str = response['location']
+          limit  -= 1
+        else
+          return response
+        end
+      end
+      raise RuntimeError('too many HTTP redirects') if limit == 0
+    end
+
+    def cache_key
+      @cache_key ||= Digest::SHA1.hexdigest(@path)
+    end
+  end
+end

--- a/yarp/fetcher.rb
+++ b/yarp/fetcher.rb
@@ -1,15 +1,15 @@
 require 'digest'
 require 'uri'
 require 'net/http'
+require 'thread'
+require 'yarp/cache'
+require 'yarp/fetcher/queue'
 
 module Yarp
   class Fetcher
+    FETCH_REDIRECTS_LIMIT = 10
 
-    @paths_being_fetched = {}
-
-    singleton_class.class_eval do
-      attr_accessor :paths_being_fetched
-    end
+    attr_reader :path
 
     def self.fetch(path)
       new(path).fetch
@@ -20,48 +20,30 @@ module Yarp
     end
 
     def fetch
-      cached_value = self.class.cache.get(cache_key)
+      cached_value = Yarp::Cache.instance.get(cache_key)
       return cached_value if cached_value
-      async_fetch
+      Yarp::Fetcher::Queue.instance << self
       return
     end
 
-    def self.cache
-      @cache ||= Yarp::Cache::Tee.new(
-        caches: {
-          memcache: Yarp::Cache::Memcache.new,
-          file:     Yarp::Cache::File.new,
-          null:     Yarp::Cache::Null.new
-        },
-        condition: lambda { |key, value|
-          value.last.length <= ENV['YARP_CACHE_THRESHOLD'].to_i ?
-            ENV['YARP_SMALL_CACHE'].to_sym :
-            ENV['YARP_LARGE_CACHE'].to_sym
-        }
-      )
+    def fetch_from_upstream
+      Yarp::Cache.instance.fetch(cache_key, ENV['YARP_CACHE_TTL'].to_i) do
+        Log.debug "FETCH #{@path}"
+        response = fetch_with_redirects
+        kept_headers = response.to_hash.slice('content-type', 'content-length')
+        if response.code != '200'
+          return [response.code.to_i, response.to_hash, response.body]
+        end
+        [kept_headers, response.body]
+      end
     end
 
     private
 
-    def async_fetch
-      return if self.class.paths_being_fetched[@path]
-      self.class.paths_being_fetched[@path] = Thread.new(@path, cache_key) do |request_path, key|
-        self.class.cache.fetch(key, ENV['YARP_CACHE_TTL'].to_i) do
-          uri = URI("#{ENV['YARP_UPSTREAM']}#{request_path}")
-          Log.debug "FETCH #{uri}"
-          response = self.class.fetch_with_redirects(uri)
-          kept_headers = response.to_hash.slice('content-type', 'content-length')
-          if response.code != '200'
-            return [response.code.to_i, response.to_hash, response.body]
-          end
-          [kept_headers, response.body]
-        end
-        self.class.paths_being_fetched.delete(request_path)
-      end
-      self.class.paths_being_fetched[@path].abort_on_exception = true
-    end
+    def fetch_with_redirects
+      limit = FETCH_REDIRECTS_LIMIT
+      uri_str = "#{ENV['YARP_UPSTREAM']}#{@path}"
 
-    def self.fetch_with_redirects(uri_str, limit = 10)
       while limit > 0
         begin
           response = Net::HTTP.get_response(URI(uri_str))

--- a/yarp/fetcher.rb
+++ b/yarp/fetcher.rb
@@ -4,6 +4,7 @@ require 'net/http'
 require 'thread'
 require 'yarp/cache'
 require 'yarp/fetcher/queue'
+require 'yarp/fetcher/spawner'
 
 module Yarp
   class Fetcher

--- a/yarp/fetcher.rb
+++ b/yarp/fetcher.rb
@@ -16,7 +16,7 @@ module Yarp
       @path = path
     end
 
-    def fetch
+    def perform
       cached_value = Yarp::ConcreteCache.instance.get(cache_key)
       return cached_value if cached_value
       Yarp::Fetcher::Queue.instance << self

--- a/yarp/fetcher.rb
+++ b/yarp/fetcher.rb
@@ -2,7 +2,7 @@ require 'digest'
 require 'uri'
 require 'net/http'
 require 'thread'
-require 'yarp/cache'
+require 'yarp/concrete_cache'
 require 'yarp/fetcher/queue'
 require 'yarp/fetcher/spawner'
 
@@ -17,14 +17,14 @@ module Yarp
     end
 
     def fetch
-      cached_value = Yarp::Cache.instance.get(cache_key)
+      cached_value = Yarp::ConcreteCache.instance.get(cache_key)
       return cached_value if cached_value
       Yarp::Fetcher::Queue.instance << self
       return
     end
 
     def fetch_from_upstream
-      Yarp::Cache.instance.fetch(cache_key, ENV['YARP_CACHE_TTL'].to_i) do
+      Yarp::ConcreteCache.instance.fetch(cache_key, ENV['YARP_CACHE_TTL'].to_i) do
         Log.debug "FETCH #{@path}"
         response = fetch_with_redirects
         kept_headers = response.to_hash.slice('content-type', 'content-length')

--- a/yarp/fetcher.rb
+++ b/yarp/fetcher.rb
@@ -12,10 +12,6 @@ module Yarp
 
     attr_reader :path
 
-    def self.fetch(path)
-      new(path).fetch
-    end
-
     def initialize(path)
       @path = path
     end

--- a/yarp/fetcher/queue.rb
+++ b/yarp/fetcher/queue.rb
@@ -16,8 +16,10 @@ module Yarp
       end
 
       def <<(fetcher)
-        return nil if @queued_paths.include?(fetcher.path)
-        @queued_paths << fetcher.path
+        Mutex.new.synchronize do
+          return nil if @queued_paths.include?(fetcher.path)
+          @queued_paths << fetcher.path
+        end
         @queue << fetcher
       end
 

--- a/yarp/fetcher/queue.rb
+++ b/yarp/fetcher/queue.rb
@@ -1,0 +1,29 @@
+require 'thread'
+require 'singleton'
+require 'forwardable'
+
+module Yarp
+  class Fetcher
+    class Queue
+      include Singleton
+      extend Forwardable
+
+      def_delegators :@queue, :pop
+
+      def initialize
+        @queue = ::Queue.new
+        @queued_paths = []
+      end
+
+      def <<(fetcher)
+        return nil if @queued_paths.include?(fetcher.path)
+        @queued_paths << fetcher.path
+        @queue << fetcher
+      end
+
+      def done(fetcher)
+        @queued_paths.delete(fetcher.path)
+      end
+    end
+  end
+end

--- a/yarp/fetcher/queue.rb
+++ b/yarp/fetcher/queue.rb
@@ -8,7 +8,7 @@ module Yarp
       include Singleton
       extend Forwardable
 
-      def_delegators :@queue, :pop
+      def_delegators :@queue, :pop, :length
 
       def initialize
         @queue = ::Queue.new
@@ -23,6 +23,10 @@ module Yarp
 
       def done(fetcher)
         @queued_paths.delete(fetcher.path)
+      end
+
+      def clear
+        initialize
       end
     end
   end

--- a/yarp/fetcher/spawner.rb
+++ b/yarp/fetcher/spawner.rb
@@ -1,0 +1,33 @@
+require 'yarp/fetcher/queue'
+require 'yarp/fetcher'
+
+module Yarp
+  class Fetcher
+    module Spawner
+      extend self
+      FETCHING_THREADS = 4
+
+      def spawn_fetching_threads
+        FETCHING_THREADS.times do
+          spawn_fetching_thread
+        end
+      end
+
+      def spawn_fetching_thread
+        thread = Thread.new do
+          begin
+            while fetcher = Queue.instance.pop
+              fetcher.fetch_from_upstream
+              Queue.instance.done(fetcher)
+            end
+          rescue Exception => e
+            spawn_fetching_thread
+            raise e
+          end
+        end
+        thread.abort_on_exception = true
+        thread
+      end
+    end
+  end
+end

--- a/yarp/fetcher/spawner.rb
+++ b/yarp/fetcher/spawner.rb
@@ -18,8 +18,11 @@ module Yarp
         thread = Thread.new do
           begin
             while fetcher = Queue.instance.pop
-              fetcher.fetch_from_upstream
-              Queue.instance.done(fetcher)
+              begin
+                fetcher.fetch_from_upstream
+              ensure
+                Queue.instance.done(fetcher)
+              end
             end
           rescue Exception => e
             spawn_fetching_thread

--- a/yarp/fetcher/spawner.rb
+++ b/yarp/fetcher/spawner.rb
@@ -4,6 +4,7 @@ require 'yarp/fetcher'
 module Yarp
   class Fetcher
     module Spawner
+
       extend self
       FETCHING_THREADS = 4
 

--- a/yarp/fetcher/spawner.rb
+++ b/yarp/fetcher/spawner.rb
@@ -26,7 +26,6 @@ module Yarp
             raise e
           end
         end
-        thread.abort_on_exception = true
         thread
       end
     end

--- a/yarp/logger.rb
+++ b/yarp/logger.rb
@@ -1,4 +1,3 @@
-require 'yarp'
 require 'logger'
 require 'term/ansicolor'
 


### PR DESCRIPTION
https://github.com/mezis/yarp/issues/1 :

> When a request is made for something that's not in the cache, we currently synchronously fetch from upstream, and return the results.
> 
> It would be faster, in this case, to redirect to upstream asynchronously (through DJ for instance) prime the cache.
> This is faster for the client on 1st request ; the drawback (which is not our concern) is 2 identical requests made to upstream.

Implementation:
When user hits yarp and there is no entry in cache, then s/he is redirected to rubygems, while task to fetch resource from rubygems is enqueued. There are 4 threads which are listening to the queue for resources to fetch.
