### PR TITLE
Disable dotenv file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Thake a long look at the [`.env`](.env) file, as most
 configuration options for Yarp are there.
 
 
+### Disable dotenv file
+
+For this you need use additional ENV variable `YARP_DISABLE_DOTENV=1`
+You can provide ENV variables via bash from any file.
+For example:
+   $ export $(cat /any_path/.rbenv-vars | xargs) && export YARP_DISABLE_DOTENV=1 && bundle exec rainbows -c rainbows.rb
+
+
 ### License
 
 Yarp is released under the MIT licence.

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ configuration options for Yarp are there.
 
 ### Disable dotenv file
 
-For this you need use additional ENV variable `YARP_DISABLE_DOTENV=1`
-You can provide ENV variables via bash from any file.
-For example:
-   $ export $(cat /any_path/.rbenv-vars | xargs) && export YARP_DISABLE_DOTENV=1 && bundle exec rainbows -c rainbows.rb
+For this you need use additional ENV variable `YARP_DISABLE_DOTENV=1`.
+You can provide ENV variables via bash from any file, for example:
+
+    $ export $(cat /any_path/.rbenv-vars | xargs) && export YARP_DISABLE_DOTENV=1 && bundle exec rainbows -c rainbows.rb
 
 
 ### License

--- a/config.ru
+++ b/config.ru
@@ -1,8 +1,10 @@
 lib = File.expand_path('../', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require 'dotenv'
-Dotenv.load!
+if ENV['YARP_DISABLE_DOTENV'].empty?
+  require 'dotenv'
+  Dotenv.load!
+end
 
 require 'yarp/app'
 require 'yarp/initializers/new_relic'

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,7 @@
 lib = File.expand_path('../', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-if ENV['YARP_DISABLE_DOTENV'].empty?
+if ENV['YARP_DISABLE_DOTENV'].nil?
   require 'dotenv'
   Dotenv.load!
 end


### PR DESCRIPTION
I use `.rbenv-vars` to set up environment variables.
So this patch add ability to disable `.env` file in repo and use any another file in system with command, for example `export $(cat /u/rubygems_proxy/.rbenv-vars | xargs) && cd /u/rubygems_proxy/current && bundle exec rainbows -c rainbows.rb` 
